### PR TITLE
switch to ibmpkcs11.so filename to allow a standalone use 

### DIFF
--- a/openssl.cnf.sample.in
+++ b/openssl.cnf.sample.in
@@ -18,7 +18,7 @@ ibmpkcs11 = ibmpkcs11_section
 
 [ibmpkcs11_section]
 SLOT_ID=0
-dynamic_path = @LIBDIR@/libibmpkcs11.so
+dynamic_path = @LIBDIR@/ibmpkcs11.so
 engine_id = ibmpkcs11
 #
 # The following algorithms will be enabled by these parameters

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -2,7 +2,8 @@ lib_LTLIBRARIES=ibmpkcs11.la
 
 ibmpkcs11_la_CFLAGS=-I./include
 
-ibmpkcs11_la_LDFLAGS=@LIBS@ -lc -lpthread -ldl
+ibmpkcs11_la_LIBADD=@LIBS@ -lc -lpthread -ldl
+ibmpkcs11_la_LDFLAGS=-module -version-info 0:1:0 -shared -no-undefined -avoid-version
 ibmpkcs11_la_SOURCES=e_pkcs11.c \
 			e_pkcs11_err.c \
 			e_pkcs11.h \

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -1,9 +1,9 @@
-lib_LTLIBRARIES=libibmpkcs11.la
+lib_LTLIBRARIES=ibmpkcs11.la
 
-libibmpkcs11_la_CFLAGS=-I./include
+ibmpkcs11_la_CFLAGS=-I./include
 
-libibmpkcs11_la_LDFLAGS=@LIBS@ -lc -lpthread -ldl
-libibmpkcs11_la_SOURCES=e_pkcs11.c \
+ibmpkcs11_la_LDFLAGS=@LIBS@ -lc -lpthread -ldl
+ibmpkcs11_la_SOURCES=e_pkcs11.c \
 			e_pkcs11_err.c \
 			e_pkcs11.h \
 			pkcs11f.h \


### PR DESCRIPTION
similarly as in https://github.com/opencryptoki/openssl-ibmca/pull/27 switch to "non-lib" filename, in addition switch linking to a module from a shared lib